### PR TITLE
Remove Slate/Skate specific "&_fd=0" URL param

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,7 +80,7 @@ theme_root="${THEME_ROOT:-.}"
 step "Creating development theme"
 theme_push_log="$(mktemp)"
 shopify theme push --development --json $theme_root > "$theme_push_log" && cat "$theme_push_log"
-preview_url="$(cat "$theme_push_log" | tail -n 1 | jq -r '.theme.preview_url')&_fd=0"
+preview_url="$(cat "$theme_push_log" | tail -n 1 | jq -r '.theme.preview_url')"
 editor_url="$(cat "$theme_push_log" | tail -n 1 | jq -r '.theme.editor_url')"
 
 echo "::set-output name=preview_url::$preview_url"


### PR DESCRIPTION
Sazerac store using Nighthawk theme can't run cypress because of this `_fd` param. II think it's specific to Skate / Slatehttps://github.com/Shopify/slate/issues/5#issuecomment-300793576